### PR TITLE
Amend AFNetworking to version '4.0'

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'AFNetworking', '~> 3.0'
+pod 'AFNetworking', '~> 4.0'


### PR DESCRIPTION
Hello,

Please can AFNetworking be updated to version '4.0'?

It uses WKWebView in favour of UIWebView which is deprecated and causes the whole app to be rejected by apple.

See:
https://github.com/AFNetworking/AFNetworking/pull/4439
https://github.com/AFNetworking/AFNetworking/pull/4430

Cheers